### PR TITLE
fix procfile syntax

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: bundle exec rackup -p $PORT
 worker: bundle exec rake resque:work QUEUES=main INTERVAL=1 TERM_CHILD=1
-worker_milestone: bundle exec rake resque:work QUEUES=milestone,main,gh_update INTERVAL=1 TERM_CHILD=1
+workermilestone: bundle exec rake resque:work QUEUES=milestone,main,gh_update INTERVAL=1 TERM_CHILD=1
 scheduler: bundle exec rake resque:scheduler


### PR DESCRIPTION
According to [heroku](https://devcenter.heroku.com/articles/procfile#declaring-process-types)

> <process type> – an alphanumeric string, is a name for your command, such as web, worker, urgentworker, clock, etc.

